### PR TITLE
Relax pubcontrol constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ author_email='justin@fanout.io',
 url='https://github.com/fanout/pyfanout',
 license='MIT',
 py_modules=['fanout'],
-install_requires=['pubcontrol>=2.2.0,<3'],
+install_requires=['pubcontrol>=2.2.0,<4'],
 classifiers=[
 	'Topic :: Utilities',
 	'License :: OSI Approved :: MIT License'


### PR DESCRIPTION
New pip versions have implemented stricter dependency resolution. This causes backtracking when requiring pubcontrol 3.0.0, even though this package is compatible with the newer version. This should avoid the backtracking.